### PR TITLE
Fix #33 and capture sound with parse_active_scene for #54

### DIFF
--- a/capture.py
+++ b/capture.py
@@ -138,6 +138,7 @@ def capture(camera=None,
         cmds.setFocus(panel)
 
         with contextlib.nested(
+             _disabled_inview_messages(),
              _maintain_camera(panel, camera),
              _applied_viewport_options(viewport_options, panel),
              _applied_camera_options(camera_options, panel),
@@ -722,6 +723,17 @@ def _maintain_camera(panel, camera):
     finally:
         for camera, renderable in state.iteritems():
             cmds.setAttr(camera + ".rnd", renderable)
+
+
+@contextlib.contextmanager
+def _disabled_inview_messages():
+    """Disable in-view help messages during the context"""
+    original = cmds.optionVar(q="inViewMessageEnable")
+    cmds.optionVar(iv=("inViewMessageEnable", 0))
+    try:
+        yield
+    finally:
+        cmds.optionVar(iv=("inViewMessageEnable", original))
 
 
 def _image_to_clipboard(path):

--- a/capture.py
+++ b/capture.py
@@ -9,6 +9,7 @@ import sys
 import contextlib
 
 from maya import cmds
+from maya import mel
 
 version_info = (2, 1, 0)
 
@@ -429,6 +430,8 @@ def parse_active_scene():
 
     """
 
+    time_control = mel.eval("$gPlayBackSlider = $gPlayBackSlider")
+
     return {
         "start_frame": cmds.playbackOptions(minTime=True, query=True),
         "end_frame": cmds.playbackOptions(maxTime=True, query=True),
@@ -442,7 +445,8 @@ def parse_active_scene():
                        else False),
         "show_ornaments": (True if cmds.optionVar(query="playblastShowOrnaments")
                        else False),
-        "quality": cmds.optionVar(query="playblastQuality")
+        "quality": cmds.optionVar(query="playblastQuality"),
+        "sound": cmds.timeControl(time_control, q=True, sound=True) or None
     }
 
 


### PR DESCRIPTION
- Fix #33 where Maya 2016 would pop up an in-view message when the artist has that feature enabled (enabled by default in 2016)
- With the added support for the `sound` argument allow the parsing of the active sound with #54 with `parse_active_scene()`. It is important to note that since this requires the "sound" node to be in the scene to playblast correctly this might be somewhat unexpected when building *presets* as described in the `README.md`. When unavailable in the scene this would result in a warning message when playblasting.

For example:

```python
# say current scene has an active audio file
options = capture.parse_active_scene()
assert "sound" in options
assert options["sound"] is not None

# force create a new scene
maya.cmds.file(new=True, force=True)
capture.capture(**options)

# this would result in a warning about "missing sound file"
# since the new scene does not have a sound node
```