### PR TITLE
Add Maya 2017 (PySide2) compatibility

### DIFF
--- a/capture.py
+++ b/capture.py
@@ -15,7 +15,7 @@ try:
     from PySide2 import QtGui, QtWidgets
 except ImportError:
     from PySide import QtGui
-    from PySide import QtGui as QtWidgets
+    QtWidgets = QtGui
 
 version_info = (2, 1, 1)
 

--- a/capture.py
+++ b/capture.py
@@ -795,8 +795,8 @@ def _in_standalone():
 #
 # --------------------------------
 
-version = cmds.about(version=True)
-if "2016" in version:
+version = mel.eval("getApplicationVersionAsFloat")
+if version > 2015:
     Viewport2Options.update({
         "hwFogAlpha": 1.0,
         "hwFogFalloff": 0,

--- a/capture.py
+++ b/capture.py
@@ -17,7 +17,7 @@ except ImportError:
     from PySide import QtGui
     QtWidgets = QtGui
 
-version_info = (2, 1, 1)
+version_info = (2, 2, 0)
 
 __version__ = "%s.%s.%s" % version_info
 __license__ = "MIT"

--- a/capture.py
+++ b/capture.py
@@ -11,6 +11,12 @@ import contextlib
 from maya import cmds
 from maya import mel
 
+try:
+    from PySide2 import QtGui, QtWidgets
+except ImportError:
+    from PySide import QtGui
+    from PySide import QtGui as QtWidgets
+
 version_info = (2, 1, 1)
 
 __version__ = "%s.%s.%s" % version_info
@@ -765,10 +771,9 @@ def _image_to_clipboard(path):
     if _in_standalone():
         raise Exception("Cannot copy to clipboard from Maya Standalone")
 
-    import PySide.QtGui
-    image = PySide.QtGui.QImage(path)
-    clipboard = PySide.QtGui.QApplication.clipboard()
-    clipboard.setImage(image, mode=PySide.QtGui.QClipboard.Clipboard)
+    image = QtGui.QImage(path)
+    clipboard = QtWidgets.QApplication.clipboard()
+    clipboard.setImage(image, mode=QtGui.QClipboard.Clipboard)
 
 
 def _get_screen_size():
@@ -776,8 +781,7 @@ def _get_screen_size():
     if _in_standalone():
         return [0, 0]
 
-    import PySide.QtGui
-    rect = PySide.QtGui.QDesktopWidget().screenGeometry(-1)
+    rect = QtWidgets.QDesktopWidget().screenGeometry(-1)
     return [rect.width(), rect.height()]
 
 


### PR DESCRIPTION
Similar to #68 addresses Maya 2017 compatibility but does so without the need of `Qt.py` and instead uses a simple try-except statement in the form of:

```python
try:
    from PySide2 import QtGui, QtWidgets
except ImportError:
    from PySide import QtGui
    from PySide import QtGui as QtWidgets
```

Unlike #68 this does not change `capture` into a package, it remains a single module.

Tested in Maya 2016 and Maya 2017.

