### PR TITLE
Add missing restore logic in _applied_viewport_options() and _isolated_nodes() contextmanagers

### DIFF
--- a/capture.py
+++ b/capture.py
@@ -760,7 +760,12 @@ def _isolated_nodes(nodes, panel):
         cmds.isolateSelect(panel, state=True)
         for obj in nodes:
             cmds.isolateSelect(panel, addDagObject=obj)
-    yield
+
+    try:
+        yield
+    finally:
+        if nodes is not None:
+            cmds.isolateSelect(panel, state=False)
 
 
 @contextlib.contextmanager


### PR DESCRIPTION
There is a part in the code where this happens:
```
        with contextlib.nested(
             _disabled_inview_messages(),
             _maintain_camera(panel, camera),
             _applied_viewport_options(viewport_options, panel),
             _applied_camera_options(camera_options, panel),
             _applied_display_options(display_options),
             _applied_viewport2_options(viewport2_options),
             _isolated_nodes(isolate, panel),
             _maintained_time()):
```
and I noticed everything in that nested contextlib *except* `_applied_viewport_options()` and `_isolated_nodes()` were restoring original settings on exit, so I fixed it.

Since an independent panel is used in the `capture()` function, the missing cleanup was not important, but it _is_ if anyone uses the contextmanagers independently (and some are useful so I could see that happening.)