### PR TITLE
Add option for playblasting from the camera sequencer.

### DIFF
--- a/capture.py
+++ b/capture.py
@@ -45,6 +45,7 @@ def capture(camera=None,
             overwrite=False,
             frame_padding=4,
             raw_frame_numbers=False,
+            sequence_time=False,
             camera_options=None,
             display_options=None,
             viewport_options=None,
@@ -84,6 +85,10 @@ def capture(camera=None,
             frame numbers from the scene or capture to a sequence starting at
             zero. Defaults to False. When set to True `viewer` can't be used
             and will be forced to False.
+        sequence_time (bool, optional): Whether or not to playblast using the
+            camera sequencer. Defaults to False. When set to True the value of
+            `camera` will be ignored and the cameras from the sequencer will
+            be used instead.
         camera_options (dict, optional): Supplied camera options,
             using `CameraOptions`
         display_options (dict, optional): Supplied display
@@ -193,6 +198,7 @@ def capture(camera=None,
                     widthHeight=[width, height],
                     rawFrameNumbers=raw_frame_numbers,
                     framePadding=frame_padding,
+                    sequenceTime=sequence_time,
                     **playblast_kwargs)
 
         return output

--- a/capture.py
+++ b/capture.py
@@ -21,7 +21,7 @@ except ImportError:
         from PySide import QtGui
         QtWidgets = QtGui
 
-version_info = (2, 5, 0)
+version_info = (2, 6, 0)
 
 __version__ = "%s.%s.%s" % version_info
 __license__ = "MIT"

--- a/capture.py
+++ b/capture.py
@@ -88,7 +88,8 @@ def capture(camera=None,
         sequence_time (bool, optional): Whether or not to playblast using the
             camera sequencer. Defaults to False. When set to True the value of
             `camera` will be ignored and the cameras from the sequencer will
-            be used instead.
+            be used instead. Additionally, the `start_frame` and `end_frame`
+            values will be in sequence time instead of scene frame numbers.
         camera_options (dict, optional): Supplied camera options,
             using `CameraOptions`
         display_options (dict, optional): Supplied display
@@ -130,10 +131,21 @@ def capture(camera=None,
         ratio = cmds.getAttr("defaultResolution.deviceAspectRatio")
         height = round(width / ratio)
 
-    if start_frame is None:
-        start_frame = cmds.playbackOptions(minTime=True, query=True)
-    if end_frame is None:
-        end_frame = cmds.playbackOptions(maxTime=True, query=True)
+    # Set frame range if no custom frame range specified
+    if sequence_time:
+        # Get frames from the Camera Sequencer
+        sequencer = cmds.sequenceManager(query=True, writableSequencer=True)
+
+        if start_frame is None:
+            start_frame = cmds.getAttr(sequencer + ".minFrame")
+        if end_frame is None:
+            end_frame = cmds.getAttr(sequencer + ".maxFrame")
+    else:
+        # Get frames from the timeline
+        if start_frame is None:
+            start_frame = cmds.playbackOptions(minTime=True, query=True)
+        if end_frame is None:
+            end_frame = cmds.playbackOptions(maxTime=True, query=True)
 
     # (#74) Bugfix: `maya.cmds.playblast` will raise an error when playblasting
     # with `rawFrameNumbers` set to True but no explicit `frames` provided.


### PR DESCRIPTION
Added option for setting the `sequenceTime` boolean on the playblast function. When `sequenceTime` is set to true, playblasting will ignore the camera passed to it and use the cameras from the sequencer instead. `startTime` and `endTime` are computed in sequence time instead of global time.