### PR TITLE
Add ViewportOption for two sided lighting toggle

### DIFF
--- a/capture.py
+++ b/capture.py
@@ -315,7 +315,11 @@ ViewportOptions = {
     "displayAppearance": 'smoothShaded',
     "selectionHiliteDisplay": False,
     "headsUpDisplay": True,
+
+    # Since Maya 2024, this setting applies to Viewport 2.0
+    # in place of `singleSidedLighting` below.
     "twoSidedLighting": False,
+
     # object display
     "imagePlane": True,
     "nurbsCurves": False,
@@ -365,7 +369,10 @@ Viewport2Options = {
     "motionBlurType": 0,
     "multiSampleCount": 8,
     "multiSampleEnable": False,
+
+    # Since Maya 2024, this setting only applies to the Maya Hardware renderer
     "singleSidedLighting": False,
+
     "ssaoEnable": False,
     "ssaoAmount": 1.0,
     "ssaoFilterRadius": 16,

--- a/capture.py
+++ b/capture.py
@@ -315,6 +315,7 @@ ViewportOptions = {
     "displayAppearance": 'smoothShaded',
     "selectionHiliteDisplay": False,
     "headsUpDisplay": True,
+    "twoSidedLighting": False,
     # object display
     "imagePlane": True,
     "nurbsCurves": False,


### PR DESCRIPTION
As far as I can tell, the toggle at `Viewport2Options.singleSidedLighting` doesn't actually have any effect on whether or not the playblast uses double-sided normals for lighting or not. It looks like that toggle only affects the render when doing a batch render with Maya Hardware 2.0. 

This PR adds the `ViewportOptions.twoSidedLighting` toggle, which will affect whether double-sided normals are used in a playblast.

This PR is necessary because the current behavior of `capture` is to always use single-sided normals. You can pass in the "twoSidedLighting" key yourself, but this is not documented and is not captured by `parse_view`.

Tested on Maya 2024.1

Thanks!