### PR TITLE
Add context manager to only enable 2D pan and zoom if it is enabled in render

### DIFF
--- a/capture.py
+++ b/capture.py
@@ -190,6 +190,7 @@ def capture(camera=None,
 
         with _disabled_inview_messages(),\
              _maintain_camera(panel, camera),\
+             _maintain_pan_zoom(camera),\
              _maintain_sequence_time_panel(),\
              _applied_viewport_options(viewport_options, panel),\
              _applied_camera_options(camera_options, panel, use_camera_sequencer),\
@@ -813,6 +814,18 @@ def _maintain_camera(panel, camera):
     finally:
         for camera, renderable in state.items():
             cmds.setAttr(camera + ".rnd", renderable)
+
+
+@contextlib.contextmanager
+def _maintain_pan_zoom(camera):
+    state = cmds.camera(camera, query=True, panZoomEnabled=True)
+    if not cmds.camera(camera, query=True, renderPanZoom=True):
+        cmds.camera(camera, edit=True, panZoomEnabled=False)
+
+    try:
+        yield
+    finally:
+        cmds.camera(camera, edit=True, panZoomEnabled=state)
 
 
 @contextlib.contextmanager


### PR DESCRIPTION
Currently, if an artist uses 2D pan and zoom on a camera, the playblast will not match the resolution gate. This PR maintains the resolution gate during playblast this unless the artist specifically enables the "Render Pan Zoom" option. This way playblasting behavior matches behavior during rendering